### PR TITLE
Fix HDR masking color space and alpha handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,3 +164,4 @@ else()
     endif()
 endif()
 
+

--- a/data/shaders/boom-so-much-mask.effect
+++ b/data/shaders/boom-so-much-mask.effect
@@ -55,7 +55,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	buffer_color.a = max(0.0, buffer_color.a - alpha_reduction);
 	float alpha_mask = max(buffer_color.a, cur_color.a);
 	float4 c = image.Sample(textureSampler, v_in.uv);
-	return float4(c.rgb, c.a * alpha_mask);
+	return apply_alpha_mask(c, alpha_mask);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/circle-mask.effect
+++ b/data/shaders/circle-mask.effect
@@ -56,7 +56,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	d = feather_amount > 0.0f ? smoothstep(0.0f, feather_amount, -d + feather_amount) : saturate(-(d - 1.0) * zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -75,7 +75,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/common.effect
+++ b/data/shaders/common.effect
@@ -17,6 +17,11 @@ float4 pmrgba_to_rgba(float4 color)
 	return saturate(float4(color.rgb / color.a, color.a));
 }
 
+float4 apply_alpha_mask(float4 color, float mask)
+{
+	return float4(color.rgb * mask, color.a * mask);
+}
+
 float4 adjust_brightness(float4 color, float brightness)
 {
 	return saturate(float4(color.rgb + brightness, color.a));

--- a/data/shaders/ellipse-mask.effect
+++ b/data/shaders/ellipse-mask.effect
@@ -97,7 +97,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	d = feather_amount > 0.0f ? smoothstep(0.0f, feather_amount, -d + feather_amount) : saturate(-(d - 1.0) * zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -117,7 +117,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/feather-mask.effect
+++ b/data/shaders/feather-mask.effect
@@ -39,7 +39,7 @@ float4 PSFeather(VertData v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
 	float4 dist_texture = distance_field.Sample(sdfSampler, v_in.uv);
 	float mask = saturate(distance(coord, dist_texture.xy) / feather_size);
-	float4 retColor = float4(rgba.r, rgba.g, rgba.b, rgba.a * mask);
+	float4 retColor = float4(rgba.rgb * mask, rgba.a * mask);
 	return retColor;
 }
 

--- a/data/shaders/gradient-mask.effect
+++ b/data/shaders/gradient-mask.effect
@@ -52,7 +52,7 @@ float4 mainAlphaImage(VertData v_in) : TARGET
 	
 	float alpha = saturate((coord_p.x - position + width / 2.0f) / width);
 	float4 col = image.Sample(textureSampler, v_in.uv);
-	return float4(col.rgb, col.a * (invert ? 1.0f - alpha : alpha));
+	return apply_alpha_mask(col, invert ? 1.0f - alpha : alpha);
 }
 
 float4 mainAdjustmentsImage(VertData v_in) : TARGET
@@ -112,7 +112,7 @@ float4 debugAlphaImage(VertData v_in) : TARGET
 		return float4(1.0f, 0.0f, 0.0f, 1.0f);
 	}
 	
-	return float4(color.rgb, color.a * (invert ? 1.0f - alpha : alpha));
+	return apply_alpha_mask(color, invert ? 1.0f - alpha : alpha);
 }
 
 

--- a/data/shaders/heart-mask.effect
+++ b/data/shaders/heart-mask.effect
@@ -74,7 +74,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	d = feather_amount > 0.0f ? smoothstep(0.0f, feather_amount, -d + feather_amount) : saturate(-d);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -93,7 +93,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/polygon-mask.effect
+++ b/data/shaders/polygon-mask.effect
@@ -69,7 +69,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	d = feather_amount > 0.0f ? smoothstep(0.0f, feather_amount, -d + feather_amount) : saturate(-d);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -88,7 +88,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/rectangular-mask.effect
+++ b/data/shaders/rectangular-mask.effect
@@ -76,7 +76,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	d = feather_amount > 0.0f ? smoothstep(0.0f, feather_amount, -d + feather_amount) : saturate(-(d - 1.0f) * zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -96,7 +96,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/render_output.effect
+++ b/data/shaders/render_output.effect
@@ -39,11 +39,25 @@ float4 mainImage(VertData v_in) : TARGET
 	return px;
 }
 
+float4 mainImageLinear(VertData v_in) : TARGET
+{
+	return output_image.Sample(textureSampler, v_in.uv);
+}
+
 technique Draw
 {
 	pass
 	{
 		vertex_shader = mainTransform(v_in);
 		pixel_shader = mainImage(v_in);
+	}
+}
+
+technique DrawLinear
+{
+	pass
+	{
+		vertex_shader = mainTransform(v_in);
+		pixel_shader = mainImageLinear(v_in);
 	}
 }

--- a/data/shaders/source-mask.effect
+++ b/data/shaders/source-mask.effect
@@ -74,7 +74,7 @@ float4 alphaImage(VertData v_in) : TARGET
 #endif
 	float alpha = multiplier * (mask.r * channel_multipliers.r + mask.g * channel_multipliers.g + mask.b * channel_multipliers.b + mask.a * channel_multipliers.a);
 	float4 color = image.Sample(textureSampler, v_in.uv);
-	return float4(color.rgb, color.a * (invert ? 1.0 - alpha : alpha));
+	return apply_alpha_mask(color, invert ? 1.0 - alpha : alpha);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET
@@ -119,7 +119,7 @@ float4 alphaThresholdImage(VertData v_in) : TARGET
 	float alpha = multiplier * (mask.r * channel_multipliers.r + mask.g * channel_multipliers.g + mask.b * channel_multipliers.b + mask.a * channel_multipliers.a);
 	alpha = step(threshold_value, alpha);
 	float4 color = image.Sample(textureSampler, v_in.uv);
-	return float4(color.rgb, color.a * (invert ? 1.0 - alpha : alpha));
+	return apply_alpha_mask(color, invert ? 1.0 - alpha : alpha);
 }
 
 float4 adjustmentsThresholdImage(VertData v_in) : TARGET
@@ -165,7 +165,7 @@ float4 alphaRangeImage(VertData v_in) : TARGET
 	float alpha = multiplier * (mask.r * channel_multipliers.r + mask.g * channel_multipliers.g + mask.b * channel_multipliers.b + mask.a * channel_multipliers.a);
 	alpha = smoothstep(range_min, range_max, alpha);
 	float4 color = image.Sample(textureSampler, v_in.uv);
-	return float4(color.rgb, color.a * (invert ? 1.0 - alpha : alpha));
+	return apply_alpha_mask(color, invert ? 1.0 - alpha : alpha);
 }
 
 float4 adjustmentsRangeImage(VertData v_in) : TARGET

--- a/data/shaders/star-mask.effect
+++ b/data/shaders/star-mask.effect
@@ -76,7 +76,7 @@ float4 alphaImage(VertData v_in) : TARGET
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
 
-	return float4(color.rgb, (1.0f - invert) * color.a * d + invert * color.a * (1.0f - d));
+	return apply_alpha_mask(color, (1.0f - invert) * d + invert * (1.0f - d));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -95,7 +95,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/superformula-mask.effect
+++ b/data/shaders/superformula-mask.effect
@@ -77,7 +77,7 @@ float4 alphaImage(VertData v_in) : TARGET
     float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
     //float4 color = image.Sample(textureSampler, (coord_p / zoom / global_scale) / uv_size);
     //return color;
-    return float4(color.rgb, (1.0f - invert) * color.a * val + invert * color.a * (1.0f - val));
+    return apply_alpha_mask(color, (1.0f - invert) * val + invert * (1.0f - val));
 }
 
 float4 alphaFrameCheckImage(VertData v_in) : TARGET
@@ -98,7 +98,7 @@ float4 alphaFrameCheckImage(VertData v_in) : TARGET
 	d = (d + alpha_zero) / (1.0 + alpha_zero);
 	float4 color = image.Sample(textureSampler, (mask_position + dist / zoom / global_scale) / uv_size);
 
-	return float4(color.rgb, color.a * d);
+	return apply_alpha_mask(color, d);
 }
 
 float4 adjustmentsImage(VertData v_in) : TARGET

--- a/data/shaders/svg-mask.effect
+++ b/data/shaders/svg-mask.effect
@@ -54,8 +54,7 @@ float4 mainImage(VertData v_in) : TARGET
 	float2 uv_svg = (coord - offset + svg_uv_size/2.0f) / svg_uv_size;
 	float4 svg = svg_image.Sample(svgSampler, uv_svg);
 	float4 c = image.Sample(textureSampler, v_in.uv);
-	c.a = c.a * svg.a;
-	return c;
+	return apply_alpha_mask(c, svg.a);
 }
 
 float4 faImage(VertData v_in) : TARGET
@@ -70,8 +69,7 @@ float4 faImage(VertData v_in) : TARGET
 	float4 c = image.Sample(textureSampler, v_in.uv);
 	svg.a = svg.a * (svg.r * (primary_alpha - secondary_alpha) + secondary_alpha);
 	svg.a = lerp(svg.a, (1.0 - svg.a), invert);
-	c.a = c.a * svg.a;
-	return c;
+	return apply_alpha_mask(c, svg.a);
 }
 
 float4 faAdjustmentsImage(VertData v_in) : TARGET

--- a/src/advanced-masks-filter.c
+++ b/src/advanced-masks-filter.c
@@ -20,6 +20,7 @@ struct obs_source_info advanced_masks_filter = {
 	.destroy = advanced_masks_destroy,
 	.update = advanced_masks_update,
 	.video_render = advanced_masks_video_render,
+	.video_get_color_space = advanced_masks_get_color_space,
 	.video_tick = advanced_masks_video_tick,
 	.get_width = advanced_masks_width,
 	.get_height = advanced_masks_height,
@@ -36,6 +37,7 @@ struct obs_source_info advanced_masks_filter_v2 = {
 	.destroy = advanced_masks_destroy,
 	.update = advanced_masks_update_v2,
 	.video_render = advanced_masks_video_render,
+	.video_get_color_space = advanced_masks_get_color_space,
 	.video_tick = advanced_masks_video_tick,
 	.get_width = advanced_masks_width,
 	.get_height = advanced_masks_height,
@@ -245,6 +247,34 @@ static void advanced_masks_video_render(void *data, gs_effect_t *effect)
 		filter->base->rendering = false;
 	}
 
+}
+
+static enum gs_color_space advanced_masks_get_color_space(
+	void *data, size_t count, const enum gs_color_space *preferred_spaces)
+{
+	advanced_masks_data_t *filter = data;
+	obs_source_t *target = obs_filter_get_target(filter->base->context);
+
+	if (!target)
+		return GS_CS_SRGB;
+
+	const enum gs_color_space potential_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		target, OBS_COUNTOF(potential_spaces), potential_spaces);
+
+	enum gs_color_space space = source_space;
+	for (size_t i = 0; i < count; ++i) {
+		space = preferred_spaces[i];
+		if (space == source_space)
+			break;
+	}
+
+	return space;
 }
 
 static bool advanced_masks_multi_pass(advanced_masks_data_t* filter)
@@ -797,18 +827,22 @@ void get_input_source(base_filter_data_t *filter)
 
 	const enum gs_color_format format =
 		gs_get_format_from_space(source_space);
+	filter->source_space = source_space;
+	filter->source_format = format;
 
 	// Set up our input_texrender to catch the output texture.
 	filter->input_texrender =
-		create_or_reset_texrender(filter->input_texrender);
+		create_or_reset_texrender_format(filter->input_texrender,
+						 format);
 
 	// Start the rendering process with our correct color space params,
 	// And set up your texrender to recieve the created texture.
 	if (obs_source_process_filter_begin_with_color_space(
 		    filter->context, format, source_space,
 		    OBS_NO_DIRECT_RENDERING) &&
-	    gs_texrender_begin(filter->input_texrender,
-			       filter->width, filter->height)) {
+	    gs_texrender_begin_with_color_space(filter->input_texrender,
+						filter->width, filter->height,
+						source_space)) {
 
 		set_blending_parameters();
 		gs_ortho(0.0f, (float)filter->width, 0.0f,
@@ -857,9 +891,11 @@ static void draw_output(advanced_masks_data_t *filter)
 				      texture);
 	}
 
-	obs_source_process_filter_end(filter->base->context, pass_through,
-				      filter->base->width,
-				      filter->base->height);
+	const char *technique =
+		source_space == GS_CS_SRGB ? "Draw" : "DrawLinear";
+	obs_source_process_filter_tech_end(filter->base->context, pass_through,
+					   filter->base->width,
+					   filter->base->height, technique);
 	//gs_blend_state_pop();
 }
 

--- a/src/advanced-masks-filter.h
+++ b/src/advanced-masks-filter.h
@@ -13,6 +13,8 @@ static uint32_t advanced_masks_height(void *data);
 static void advanced_masks_update(void *data, obs_data_t *settings);
 static void advanced_masks_update_v2(void *data, obs_data_t *settings);
 static void advanced_masks_video_render(void *data, gs_effect_t *effect);
+static enum gs_color_space advanced_masks_get_color_space(
+	void *data, size_t count, const enum gs_color_space *preferred_spaces);
 static bool advanced_masks_multi_pass(advanced_masks_data_t* filter);
 static obs_properties_t *advanced_masks_properties(void *data);
 static void advanced_masks_video_tick(void *data, float seconds);

--- a/src/base-filter.h
+++ b/src/base-filter.h
@@ -52,6 +52,8 @@ extern "C" {
 
 		uint32_t width;
 		uint32_t height;
+		enum gs_color_space source_space;
+		enum gs_color_format source_format;
 
 		uint32_t mask_effect;
 		uint32_t mask_type;

--- a/src/mask-bsm.c
+++ b/src/mask-bsm.c
@@ -273,7 +273,8 @@ static void render_bsm_alpha_mask(mask_bsm_data_t *data, base_filter_data_t *bas
 	base->output_texrender = tmp;
 
 	base->output_texrender =
-		create_or_reset_texrender(base->output_texrender);
+		create_or_reset_texrender_format(base->output_texrender,
+						 base->source_format);
 
 	gs_texrender_t *mask_source_render = get_mask_source_render(data, base);
 	if (!mask_source_render) {
@@ -292,8 +293,9 @@ static void render_bsm_alpha_mask(mask_bsm_data_t *data, base_filter_data_t *bas
 		dstr_cat(&technique, "Freeze");
 	}
 
-	if (gs_texrender_begin(base->output_texrender, base->width,
-			       base->height)) {
+	if (gs_texrender_begin_with_color_space(base->output_texrender,
+						base->width, base->height,
+						base->source_space)) {
 		gs_ortho(0.0f, (float)base->width, 0.0f, (float)base->height,
 			 -100.0f, 100.0f);
 		while (gs_effect_loop(effect, technique.array))
@@ -321,7 +323,8 @@ static void render_bsm_adjustment_mask(mask_bsm_data_t *data, base_filter_data_t
 		create_or_reset_texrender(data->bsm_mask_texrender);
 
 	base->output_texrender =
-		create_or_reset_texrender(base->output_texrender);
+		create_or_reset_texrender_format(base->output_texrender,
+						 base->source_format);
 
 	gs_texrender_t *mask_source_render = get_mask_source_render(data, base);
 	if (!mask_source_render) {
@@ -361,8 +364,9 @@ static void render_bsm_adjustment_mask(mask_bsm_data_t *data, base_filter_data_t
 
 	set_blending_parameters();
 
-	if (gs_texrender_begin(base->output_texrender, base->width,
-			       base->height)) {
+	if (gs_texrender_begin_with_color_space(base->output_texrender,
+						base->width, base->height,
+						base->source_space)) {
 		gs_ortho(0.0f, (float)base->width, 0.0f, (float)base->height,
 			 -100.0f, 100.0f);
 		while (gs_effect_loop(effect, technique.array))

--- a/src/mask-chroma-key.c
+++ b/src/mask-chroma-key.c
@@ -315,26 +315,26 @@ void render_super_key_mask(mask_chroma_key_data_t* data,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
-	else {
-		const char* technique = data->showMatte ? "DrawMatte" : "Draw";
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_effect_set_float(data->param_super_key_k, data->k);
-			gs_effect_set_float(data->param_super_key_k2, data->k2);
-			gs_effect_set_float(data->param_super_key_veil, data->veil);
+	const char* technique = data->showMatte ? "DrawMatte" : "Draw";
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_float(data->param_super_key_k, data->k);
+		gs_effect_set_float(data->param_super_key_k2, data->k2);
+		gs_effect_set_float(data->param_super_key_veil, data->veil);
 
-			gs_blend_state_push();
-			//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+		gs_blend_state_push();
+		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
 
-			obs_source_process_filter_tech_end(base->context, data->effect_super_key_mask, 0, 0, technique);
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_super_key_mask, 0, 0,
+			technique);
 
-			gs_blend_state_pop();
-		}
+		gs_blend_state_pop();
 	}
 }
 
@@ -356,34 +356,43 @@ void render_advanced_key_mask(mask_chroma_key_data_t* data,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
-	else {
-		const char* technique = data->showMatte ? "DrawMatte" : "Draw";
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			vec2_set(&pixel_size, 1.0f / (float)width, 1.0f / (float)height);
+	const char* technique = data->showMatte ? "DrawMatte" : "Draw";
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		vec2_set(&pixel_size, 1.0f / (float)width, 1.0f / (float)height);
 
-			gs_effect_set_float(data->param_advanced_key_opacity, data->opacity);
-			gs_effect_set_float(data->param_advanced_key_contrast, data->contrast);
-			gs_effect_set_float(data->param_advanced_key_brightness, data->brightness);
-			gs_effect_set_float(data->param_advanced_key_gamma, data->gamma);
-			gs_effect_set_vec2(data->param_advanced_key_chroma_key, &data->chroma);
-			gs_effect_set_vec2(data->param_advanced_key_pixel_size, &pixel_size);
-			gs_effect_set_float(data->param_advanced_key_similarity, data->similarity);
-			gs_effect_set_float(data->param_advanced_key_smoothness, data->smoothness);
-			gs_effect_set_float(data->param_advanced_key_spill, data->spill);
+		gs_effect_set_float(data->param_advanced_key_opacity,
+				    data->opacity);
+		gs_effect_set_float(data->param_advanced_key_contrast,
+				    data->contrast);
+		gs_effect_set_float(data->param_advanced_key_brightness,
+				    data->brightness);
+		gs_effect_set_float(data->param_advanced_key_gamma,
+				    data->gamma);
+		gs_effect_set_vec2(data->param_advanced_key_chroma_key,
+				   &data->chroma);
+		gs_effect_set_vec2(data->param_advanced_key_pixel_size,
+				   &pixel_size);
+		gs_effect_set_float(data->param_advanced_key_similarity,
+				    data->similarity);
+		gs_effect_set_float(data->param_advanced_key_smoothness,
+				    data->smoothness);
+		gs_effect_set_float(data->param_advanced_key_spill,
+				    data->spill);
 
-			gs_blend_state_push();
-			//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+		gs_blend_state_push();
+		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
 
-			obs_source_process_filter_tech_end(base->context, data->effect_advanced_key_mask, 0, 0, technique);
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_advanced_key_mask, 0, 0,
+			technique);
 
-			gs_blend_state_pop();
-		}
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/mask-chroma-key.c
+++ b/src/mask-chroma-key.c
@@ -326,9 +326,7 @@ void render_super_key_mask(mask_chroma_key_data_t* data,
 
 		gs_blend_state_push();
 		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_super_key_mask, 0, 0,
@@ -384,9 +382,7 @@ void render_advanced_key_mask(mask_chroma_key_data_t* data,
 
 		gs_blend_state_push();
 		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_advanced_key_mask, 0, 0,

--- a/src/mask-feather.c
+++ b/src/mask-feather.c
@@ -155,28 +155,29 @@ void render_feather_mask(mask_feather_data_t *data,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	} else {
-		const char* technique = "Draw";
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_effect_set_float(data->param_feather_size, data->featherSize);
-			gs_effect_set_texture(data->param_feather_distance_field, distance_field);
-			if (data->param_feather_uv_size) {
-				struct vec2 uv_size;
-				uv_size.x = (float)base->width;
-				uv_size.y = (float)base->height;
-				gs_effect_set_vec2(data->param_feather_uv_size, &uv_size);
-			}
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-
-			obs_source_process_filter_tech_end(base->context, effect, 0, 0, technique);
-
-			gs_blend_state_pop();
+	const char* technique = "Draw";
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_float(data->param_feather_size, data->featherSize);
+		gs_effect_set_texture(data->param_feather_distance_field,
+				      distance_field);
+		if (data->param_feather_uv_size) {
+			struct vec2 uv_size;
+			uv_size.x = (float)base->width;
+			uv_size.y = (float)base->height;
+			gs_effect_set_vec2(data->param_feather_uv_size, &uv_size);
 		}
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
+
+		obs_source_process_filter_tech_end(base->context, effect, 0, 0,
+						   technique);
+
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/mask-feather.c
+++ b/src/mask-feather.c
@@ -170,9 +170,7 @@ void render_feather_mask(mask_feather_data_t *data,
 			gs_effect_set_vec2(data->param_feather_uv_size, &uv_size);
 		}
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(base->context, effect, 0, 0,
 						   technique);

--- a/src/mask-font-awesome.cpp
+++ b/src/mask-font-awesome.cpp
@@ -681,9 +681,7 @@ void MaskFontAwesomeFilter::render(base_filter_data_t* base, color_adjustments_d
 		}
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, _effect_svg_mask, 0, 0, technique);

--- a/src/mask-font-awesome.cpp
+++ b/src/mask-font-awesome.cpp
@@ -612,83 +612,83 @@ void MaskFontAwesomeFilter::render(base_filter_data_t* base, color_adjustments_d
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
-	else {
-		const char* technique = base->mask_effect == MASK_EFFECT_ALPHA
-			? "DrawFA"
-			: "DrawFAAdjustments";
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_effect_set_texture(_param_svg_image, svg_texture);
-			struct vec2 uv_size;
-			uv_size.x = (float)base->width;
-			uv_size.y = (float)base->height;
-			gs_effect_set_vec2(_param_uv_size, &uv_size);
+	const char* technique = base->mask_effect == MASK_EFFECT_ALPHA
+					? "DrawFA"
+					: "DrawFAAdjustments";
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_texture(_param_svg_image, svg_texture);
+		struct vec2 uv_size;
+		uv_size.x = (float)base->width;
+		uv_size.y = (float)base->height;
+		gs_effect_set_vec2(_param_uv_size, &uv_size);
 
-			struct vec2 svg_uv_size;
-			svg_uv_size.x = (float)_svg_render_width;
-			svg_uv_size.y = (float)_svg_render_height;
-			gs_effect_set_vec2(_param_svg_uv_size, &svg_uv_size);
+		struct vec2 svg_uv_size;
+		svg_uv_size.x = (float)_svg_render_width;
+		svg_uv_size.y = (float)_svg_render_height;
+		gs_effect_set_vec2(_param_svg_uv_size, &svg_uv_size);
 
-			struct vec2 offset;
-			offset.x = (float)_offset_x;
-			offset.y = (float)_offset_y;
-			gs_effect_set_vec2(_param_offset, &offset);
+		struct vec2 offset;
+		offset.x = (float)_offset_x;
+		offset.y = (float)_offset_y;
+		gs_effect_set_vec2(_param_offset, &offset);
 
-			gs_effect_set_float(_param_primary_alpha, _primary_alpha);
-			gs_effect_set_float(_param_secondary_alpha, _secondary_alpha);
-			gs_effect_set_float(_param_invert, _invert ? 1.0f : 0.0f);
-			gs_effect_set_vec2(_param_anchor, &_anchor);
-			gs_effect_set_matrix4(_param_rotation_matrix, &_rotation_matrix);
-			if (base->mask_effect == MASK_EFFECT_ADJUSTMENT) {
-				const float min_brightness = color_adj->adj_brightness
-					? color_adj->min_brightness
-					: 0.0f;
-				gs_effect_set_float(_param_min_brightness,
-					min_brightness);
-				const float max_brightness = color_adj->adj_brightness
-					? color_adj->max_brightness
-					: 0.0f;
-				gs_effect_set_float(_param_max_brightness, max_brightness);
+		gs_effect_set_float(_param_primary_alpha, _primary_alpha);
+		gs_effect_set_float(_param_secondary_alpha, _secondary_alpha);
+		gs_effect_set_float(_param_invert, _invert ? 1.0f : 0.0f);
+		gs_effect_set_vec2(_param_anchor, &_anchor);
+		gs_effect_set_matrix4(_param_rotation_matrix, &_rotation_matrix);
+		if (base->mask_effect == MASK_EFFECT_ADJUSTMENT) {
+			const float min_brightness = color_adj->adj_brightness
+							     ? color_adj->min_brightness
+							     : 0.0f;
+			gs_effect_set_float(_param_min_brightness,
+					    min_brightness);
+			const float max_brightness = color_adj->adj_brightness
+							     ? color_adj->max_brightness
+							     : 0.0f;
+			gs_effect_set_float(_param_max_brightness,
+					    max_brightness);
 
-				const float min_contrast = color_adj->adj_contrast
-					? color_adj->min_contrast
-					: 0.0f;
-				gs_effect_set_float(_param_min_contrast, min_contrast);
-				const float max_contrast = color_adj->adj_contrast
-					? color_adj->max_contrast
-					: 0.0f;
-				gs_effect_set_float(_param_max_contrast, max_contrast);
+			const float min_contrast = color_adj->adj_contrast
+							   ? color_adj->min_contrast
+							   : 0.0f;
+			gs_effect_set_float(_param_min_contrast, min_contrast);
+			const float max_contrast = color_adj->adj_contrast
+							   ? color_adj->max_contrast
+							   : 0.0f;
+			gs_effect_set_float(_param_max_contrast, max_contrast);
 
-				const float min_saturation = color_adj->adj_saturation
-					? color_adj->min_saturation
-					: 1.0f;
-				gs_effect_set_float(_param_min_saturation, min_saturation);
-				const float max_saturation = color_adj->adj_saturation
-					? color_adj->max_saturation
-					: 1.0f;
-				gs_effect_set_float(_param_max_saturation, max_saturation);
+			const float min_saturation =
+				color_adj->adj_saturation ? color_adj->min_saturation : 1.0f;
+			gs_effect_set_float(_param_min_saturation,
+					    min_saturation);
+			const float max_saturation =
+				color_adj->adj_saturation ? color_adj->max_saturation : 1.0f;
+			gs_effect_set_float(_param_max_saturation,
+					    max_saturation);
 
-				const float min_hue_shift = color_adj->adj_hue_shift
-					? color_adj->min_hue_shift
-					: 0.0f;
-				gs_effect_set_float(_param_min_hue_shift, min_hue_shift);
-				const float max_hue_shift = color_adj->adj_hue_shift
-					? color_adj->max_hue_shift
-					: 1.0f;
-				gs_effect_set_float(_param_max_hue_shift, max_hue_shift);
-			}
-
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-
-			obs_source_process_filter_tech_end(base->context, _effect_svg_mask, 0, 0, technique);
-
-			gs_blend_state_pop();
+			const float min_hue_shift = color_adj->adj_hue_shift
+							    ? color_adj->min_hue_shift
+							    : 0.0f;
+			gs_effect_set_float(_param_min_hue_shift, min_hue_shift);
+			const float max_hue_shift = color_adj->adj_hue_shift
+							    ? color_adj->max_hue_shift
+							    : 1.0f;
+			gs_effect_set_float(_param_max_hue_shift, max_hue_shift);
 		}
+
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
+
+		obs_source_process_filter_tech_end(
+			base->context, _effect_svg_mask, 0, 0, technique);
+
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/mask-gradient.c
+++ b/src/mask-gradient.c
@@ -231,9 +231,7 @@ void render_gradient_mask(mask_gradient_data_t *data,
 		gs_effect_set_vec2(data->param_gradient_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_gradient_mask, 0, 0,
 			technique);

--- a/src/mask-gradient.c
+++ b/src/mask-gradient.c
@@ -169,74 +169,74 @@ void render_gradient_mask(mask_gradient_data_t *data,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
-	else {
-		char technique[32];
-		strcpy(technique, data->gradient_debug ? "Debug" : "");
-		strcat(technique, base->mask_effect == MASK_EFFECT_ALPHA
-			? "Alpha"
-			: "Adjustments");
+	char technique[32];
+	strcpy(technique, data->gradient_debug ? "Debug" : "");
+	strcat(technique, base->mask_effect == MASK_EFFECT_ALPHA
+				  ? "Alpha"
+				  : "Adjustments");
 
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_float(data->param_gradient_width,
+				    data->gradient_width);
+		gs_effect_set_bool(data->param_gradient_invert,
+				   data->gradient_invert);
+		const float position =
+			data->gradient_position - (float)base->width / 2.0f;
+		gs_effect_set_float(data->param_gradient_position, position);
+		const float rotation = data->gradient_rotation * M_PI / 180.0f;
+		gs_effect_set_float(data->param_gradient_rotation, rotation);
 
-			gs_effect_set_float(data->param_gradient_width,
-				data->gradient_width);
-			gs_effect_set_bool(data->param_gradient_invert,
-				data->gradient_invert);
-			const float position = data->gradient_position - (float)base->width / 2.0f;
-			gs_effect_set_float(data->param_gradient_position, position);
-			const float rotation = data->gradient_rotation * M_PI / 180.0f;
-			gs_effect_set_float(data->param_gradient_rotation, rotation);
+		const float min_brightness =
+			color_adj->adj_brightness ? color_adj->min_brightness : 0.0f;
+		gs_effect_set_float(data->param_gradient_min_brightness,
+				    min_brightness);
+		const float max_brightness =
+			color_adj->adj_brightness ? color_adj->max_brightness : 0.0f;
+		gs_effect_set_float(data->param_gradient_max_brightness,
+				    max_brightness);
 
-			const float min_brightness =
-				color_adj->adj_brightness ? color_adj->min_brightness : 0.0f;
-			gs_effect_set_float(data->param_gradient_min_brightness,
-				min_brightness);
-			const float max_brightness =
-				color_adj->adj_brightness ? color_adj->max_brightness : 0.0f;
-			gs_effect_set_float(data->param_gradient_max_brightness,
-				max_brightness);
+		const float min_contrast =
+			color_adj->adj_contrast ? color_adj->min_contrast : 0.0f;
+		gs_effect_set_float(data->param_gradient_min_contrast,
+				    min_contrast);
+		const float max_contrast =
+			color_adj->adj_contrast ? color_adj->max_contrast : 0.0f;
+		gs_effect_set_float(data->param_gradient_max_contrast,
+				    max_contrast);
 
-			const float min_contrast =
-				color_adj->adj_contrast ? color_adj->min_contrast : 0.0f;
-			gs_effect_set_float(data->param_gradient_min_contrast,
-				min_contrast);
-			const float max_contrast =
-				color_adj->adj_contrast ? color_adj->max_contrast : 0.0f;
-			gs_effect_set_float(data->param_gradient_max_contrast,
-				max_contrast);
+		const float min_saturation =
+			color_adj->adj_saturation ? color_adj->min_saturation : 1.0f;
+		gs_effect_set_float(data->param_gradient_min_saturation,
+				    min_saturation);
+		const float max_saturation =
+			color_adj->adj_saturation ? color_adj->max_saturation : 1.0f;
+		gs_effect_set_float(data->param_gradient_max_saturation,
+				    max_saturation);
 
-			const float min_saturation =
-				color_adj->adj_saturation ? color_adj->min_saturation : 1.0f;
-			gs_effect_set_float(data->param_gradient_min_saturation,
-				min_saturation);
-			const float max_saturation =
-				color_adj->adj_saturation ? color_adj->max_saturation : 1.0f;
-			gs_effect_set_float(data->param_gradient_max_saturation,
-				max_saturation);
+		const float min_hue_shift =
+			color_adj->adj_hue_shift ? color_adj->min_hue_shift : 0.0f;
+		gs_effect_set_float(data->param_gradient_min_hue_shift,
+				    min_hue_shift);
+		const float max_hue_shift =
+			color_adj->adj_hue_shift ? color_adj->max_hue_shift : 1.0f;
+		gs_effect_set_float(data->param_gradient_max_hue_shift,
+				    max_hue_shift);
 
-			const float min_hue_shift =
-				color_adj->adj_hue_shift ? color_adj->min_hue_shift : 0.0f;
-			gs_effect_set_float(data->param_gradient_min_hue_shift,
-				min_hue_shift);
-			const float max_hue_shift =
-				color_adj->adj_hue_shift ? color_adj->max_hue_shift : 1.0f;
-			gs_effect_set_float(data->param_gradient_max_hue_shift,
-				max_hue_shift);
+		struct vec2 uv_size;
+		uv_size.x = (float)base->width;
+		uv_size.y = (float)base->height;
+		gs_effect_set_vec2(data->param_gradient_uv_size, &uv_size);
 
-			struct vec2 uv_size;
-			uv_size.x = (float)base->width;
-			uv_size.y = (float)base->height;
-			gs_effect_set_vec2(data->param_gradient_uv_size, &uv_size);
-
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-			obs_source_process_filter_tech_end(base->context, data->effect_gradient_mask, 0, 0, technique);
-			gs_blend_state_pop();
-		}
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_gradient_mask, 0, 0,
+			technique);
+		gs_blend_state_pop();
 	}
 }

--- a/src/mask-shape.c
+++ b/src/mask-shape.c
@@ -2096,9 +2096,7 @@ static void render_rectangle_mask(mask_shape_data_t *data,
 		gs_effect_set_vec2(data->param_rectangle_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_rectangle_mask,
 						   0, 0, technique);
@@ -2226,9 +2224,7 @@ static void render_polygon_mask(mask_shape_data_t *data,
 		gs_effect_set_vec2(data->param_polygon_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_polygon_mask, 0,
 						   0, technique);
@@ -2349,9 +2345,7 @@ static void render_star_mask(mask_shape_data_t *data, base_filter_data_t *base,
 		gs_effect_set_vec2(data->param_star_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_star_mask, 0, 0, technique);
 		gs_blend_state_pop();
@@ -2464,9 +2458,7 @@ static void render_circle_mask(mask_shape_data_t *data,
 		gs_effect_set_vec2(data->param_circle_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_circle_mask, 0,
 						   0, technique);
@@ -2585,9 +2577,7 @@ static void render_heart_mask(mask_shape_data_t *data, base_filter_data_t *base,
 		gs_effect_set_vec2(data->param_heart_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_heart_mask, 0,
 						   0, technique);
@@ -2705,9 +2695,7 @@ static void render_ellipse_mask(mask_shape_data_t *data,
 		gs_effect_set_vec2(data->param_ellipse_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_ellipse_mask, 0,
 						   0, technique);
@@ -2839,9 +2827,7 @@ static void render_superfunction_mask(mask_shape_data_t *data,
 		gs_effect_set_vec2(data->param_super_uv_size, &uv_size);
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		obs_source_process_filter_tech_end(base->context,
 						   data->effect_super_mask, 0,
 						   0, technique);

--- a/src/mask-shape.c
+++ b/src/mask-shape.c
@@ -1564,9 +1564,6 @@ static void render_rectangle_mask(mask_shape_data_t *data,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2128,9 +2125,6 @@ static void render_polygon_mask(mask_shape_data_t *data,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2260,9 +2254,6 @@ static void render_star_mask(mask_shape_data_t *data, base_filter_data_t *base,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2386,9 +2377,6 @@ static void render_circle_mask(mask_shape_data_t *data,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2504,9 +2492,6 @@ static void render_heart_mask(mask_shape_data_t *data, base_filter_data_t *base,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2629,9 +2614,6 @@ static void render_ellipse_mask(mask_shape_data_t *data,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"
@@ -2761,9 +2743,6 @@ static void render_superfunction_mask(mask_shape_data_t *data,
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context),
 		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
 	const char *technique =
 		base->mask_effect == MASK_EFFECT_ALPHA && !data->frame_check
 			? "Alpha"

--- a/src/mask-source.c
+++ b/src/mask-source.c
@@ -977,49 +977,52 @@ void render_source_mask(mask_source_data_t *data, base_filter_data_t *base,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
+	set_render_params(data, color_adj);
+
+	gs_texrender_t* mask_source_render =
+		get_mask_source_texrender(data, base);
+
+	if (mask_source_render == NULL) {
 		obs_source_skip_video_filter(base->context);
+		return;
 	}
-	else {
-		set_render_params(data, color_adj);
 
-		gs_texrender_t* mask_source_render = get_mask_source_texrender(data, base);
+	gs_texture_t *source_texture =
+		gs_texrender_get_texture(mask_source_render);
 
-		if (mask_source_render == NULL) {
-			obs_source_skip_video_filter(base->context);
-			return;
-		}
-
-		gs_texture_t *source_texture = gs_texrender_get_texture(mask_source_render);
-
-		if (data->param_source_mask_source_image) {
-			gs_effect_set_texture(data->param_source_mask_source_image,
-					      source_texture);
-		}
-
-		char technique[32];
-		strcpy(technique, base->mask_effect == MASK_EFFECT_ADJUSTMENT
-					  ? "Adjustments"
-					  : "Alpha");
-		char *techniqueType =
-			data->compression_type == MASK_SOURCE_COMPRESSION_THRESHOLD
-				? "Threshold"
-			: data->compression_type == MASK_SOURCE_COMPRESSION_RANGE
-				? "Range"
-				: "";
-		strcat(technique, techniqueType);
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-
-			obs_source_process_filter_tech_end(base->context, data->effect_source_mask, 0, 0, technique);
-
-			gs_blend_state_pop();
-		}
-		gs_texrender_destroy(mask_source_render);
+	if (data->param_source_mask_source_image) {
+		gs_effect_set_texture(data->param_source_mask_source_image,
+				      source_texture);
 	}
+
+	char technique[32];
+	strcpy(technique, base->mask_effect == MASK_EFFECT_ADJUSTMENT
+				  ? "Adjustments"
+				  : "Alpha");
+	char *techniqueType =
+		data->compression_type == MASK_SOURCE_COMPRESSION_THRESHOLD
+			? "Threshold"
+		: data->compression_type == MASK_SOURCE_COMPRESSION_RANGE
+			? "Range"
+			: "";
+	strcat(technique, techniqueType);
+	const enum gs_color_format format =
+		gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
+
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_source_mask, 0, 0,
+			technique);
+
+		gs_blend_state_pop();
+	}
+	gs_texrender_destroy(mask_source_render);
 }
 
 void render_image_mask(mask_source_data_t *data, base_filter_data_t *base,
@@ -1039,95 +1042,97 @@ void render_image_mask(mask_source_data_t *data, base_filter_data_t *base,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
+	set_render_params(data, color_adj);
+
+	gs_texture_t *source_texture = NULL;
+	if (data->mask_image) {
+		source_texture = data->mask_image->texture;
 	} else {
-		set_render_params(data, color_adj);
+		obs_source_skip_video_filter(base->context);
+		return;
+	}
 
-		gs_texture_t *source_texture = NULL;
-		if (data->mask_image) {
-			source_texture = data->mask_image->texture;
-		}
-		else {
-			obs_source_skip_video_filter(base->context);
-		}
+	uint32_t base_width = gs_texture_get_width(source_texture);
+	uint32_t base_height = gs_texture_get_height(source_texture);
+	data->source_size.x = (float)base->width;
+	data->source_size.y = (float)base->height;
 
-		uint32_t base_width = gs_texture_get_width(source_texture);
-		uint32_t base_height = gs_texture_get_height(source_texture);
-		data->source_size.x = (float)base->width;
-		data->source_size.y = (float)base->height;
+	switch (data->mask_source_scale_by) {
+	case MASK_SOURCE_SCALE_BY_PERCENT:
+		data->mask_source_size.x =
+			(float)base_width * data->mask_scale_pct;
+		data->mask_source_size.y =
+			(float)base_height * data->mask_scale_pct;
+		break;
+	case MASK_SOURCE_SCALE_BY_WIDTH:
+		data->mask_source_size.x = data->mask_scale_width;
+		data->mask_source_size.y = (float)base_height *
+					   data->mask_scale_width /
+					   (float)base_width;
+		break;
+	case MASK_SOURCE_SCALE_BY_HEIGHT:
+		data->mask_source_size.y = data->mask_scale_height;
+		data->mask_source_size.x = (float)base_width *
+					   data->mask_scale_height /
+					   (float)base_height;
+		break;
+	case MASK_SOURCE_SCALE_BY_WIDTH_HEIGHT:
+		data->mask_source_size.x = data->mask_scale_width;
+		data->mask_source_size.y = data->mask_scale_height;
+		break;
+	}
 
-		switch (data->mask_source_scale_by) {
-		case MASK_SOURCE_SCALE_BY_PERCENT:
-			data->mask_source_size.x =
-				(float)base_width * data->mask_scale_pct;
-			data->mask_source_size.y =
-				(float)base_height * data->mask_scale_pct;
-			break;
-		case MASK_SOURCE_SCALE_BY_WIDTH:
-			data->mask_source_size.x = data->mask_scale_width;
-			data->mask_source_size.y = (float)base_height *
-						   data->mask_scale_width /
-						   (float)base_width;
-			break;
-		case MASK_SOURCE_SCALE_BY_HEIGHT:
-			data->mask_source_size.y = data->mask_scale_height;
-			data->mask_source_size.x = (float)base_width *
-						   data->mask_scale_height /
-						   (float)base_height;
-			break;
-		case MASK_SOURCE_SCALE_BY_WIDTH_HEIGHT:
-			data->mask_source_size.x = data->mask_scale_width;
-			data->mask_source_size.y = data->mask_scale_height;
-			break;
-		}
+	if (data->param_source_source_image_size) {
+		gs_effect_set_vec2(data->param_source_source_image_size,
+				   &data->source_size);
+	}
 
-		if (data->param_source_source_image_size) {
-			gs_effect_set_vec2(data->param_source_source_image_size,
-					   &data->source_size);
-		}
+	if (data->param_source_mask_image_size) {
+		gs_effect_set_vec2(data->param_source_mask_image_size,
+				   &data->mask_source_size);
+	}
 
-		if (data->param_source_mask_image_size) {
-			gs_effect_set_vec2(data->param_source_mask_image_size,
-					   &data->mask_source_size);
-		}
+	if (data->param_source_mask_offset) {
+		gs_effect_set_vec2(data->param_source_mask_offset,
+				   &data->mask_offset);
+	}
 
-		if (data->param_source_mask_offset) {
-			gs_effect_set_vec2(data->param_source_mask_offset,
-					   &data->mask_offset);
-		}
+	if (data->param_source_mask_source_image && source_texture) {
+		gs_effect_set_texture(data->param_source_mask_source_image,
+				      source_texture);
+	} else {
+		gs_texrender_t *tmp = base->output_texrender;
+		base->output_texrender = base->input_texrender;
+		base->input_texrender = tmp;
+		return;
+	}
 
-		if (data->param_source_mask_source_image && source_texture) {
-			gs_effect_set_texture(data->param_source_mask_source_image,
-					      source_texture);
-		} else {
-			gs_texrender_t *tmp = base->output_texrender;
-			base->output_texrender = base->input_texrender;
-			base->input_texrender = tmp;
-			return;
-		}
-
-		char technique[32];
-		strcpy(technique, base->mask_effect == MASK_EFFECT_ADJUSTMENT
-			? "Adjustments"
-			: "Alpha");
-		char* techniqueType =
-			data->compression_type == MASK_SOURCE_COMPRESSION_THRESHOLD
+	char technique[32];
+	strcpy(technique, base->mask_effect == MASK_EFFECT_ADJUSTMENT
+				  ? "Adjustments"
+				  : "Alpha");
+	char* techniqueType =
+		data->compression_type == MASK_SOURCE_COMPRESSION_THRESHOLD
 			? "Threshold"
-			: data->compression_type == MASK_SOURCE_COMPRESSION_RANGE
+		: data->compression_type == MASK_SOURCE_COMPRESSION_RANGE
 			? "Range"
 			: "";
-		strcat(technique, techniqueType);
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+	strcat(technique, techniqueType);
+	const enum gs_color_format format =
+		gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
 
-			obs_source_process_filter_tech_end(base->context, data->effect_source_mask, 0, 0, technique);
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_source_mask, 0, 0,
+			technique);
 
-			gs_blend_state_pop();
-		}
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/mask-source.c
+++ b/src/mask-source.c
@@ -1012,9 +1012,7 @@ void render_source_mask(mask_source_data_t *data, base_filter_data_t *base,
 		    base->context, format, source_space,
 		    OBS_NO_DIRECT_RENDERING)) {
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_source_mask, 0, 0,
@@ -1124,9 +1122,7 @@ void render_image_mask(mask_source_data_t *data, base_filter_data_t *base,
 		    base->context, format, source_space,
 		    OBS_NO_DIRECT_RENDERING)) {
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_source_mask, 0, 0,

--- a/src/mask-svg.c
+++ b/src/mask-svg.c
@@ -692,9 +692,7 @@ void render_mask_svg(mask_svg_data_t* data,
 		}
 
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA,
-					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
-					   GS_BLEND_INVSRCALPHA);
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		obs_source_process_filter_tech_end(
 			base->context, data->effect_svg_mask, 0, 0,

--- a/src/mask-svg.c
+++ b/src/mask-svg.c
@@ -615,84 +615,91 @@ void render_mask_svg(mask_svg_data_t* data,
 
 	const enum gs_color_space source_space = obs_source_get_color_space(
 		obs_filter_get_target(base->context), OBS_COUNTOF(preferred_spaces), preferred_spaces);
-	if (source_space == GS_CS_709_EXTENDED) {
-		obs_source_skip_video_filter(base->context);
-	}
-	else {
-		const char* technique = base->mask_effect == MASK_EFFECT_ALPHA
-			? "DrawFA"
-			: "DrawFAAdjustments";
-		const enum gs_color_format format = gs_get_format_from_space(source_space);
-		if (obs_source_process_filter_begin_with_color_space(base->context, format, source_space,
-			OBS_NO_DIRECT_RENDERING)) {
-			gs_effect_set_texture(data->param_svg_image, svg_texture);
-			struct vec2 uv_size;
-			uv_size.x = (float)base->width;
-			uv_size.y = (float)base->height;
-			gs_effect_set_vec2(data->param_uv_size, &uv_size);
+	const char* technique = base->mask_effect == MASK_EFFECT_ALPHA
+					? "DrawFA"
+					: "DrawFAAdjustments";
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    base->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_texture(data->param_svg_image, svg_texture);
+		struct vec2 uv_size;
+		uv_size.x = (float)base->width;
+		uv_size.y = (float)base->height;
+		gs_effect_set_vec2(data->param_uv_size, &uv_size);
 
-			struct vec2 svg_uv_size;
-			svg_uv_size.x = (float)data->svg_render_width;
-			svg_uv_size.y = (float)data->svg_render_height;
-			gs_effect_set_vec2(data->param_svg_uv_size, &svg_uv_size);
+		struct vec2 svg_uv_size;
+		svg_uv_size.x = (float)data->svg_render_width;
+		svg_uv_size.y = (float)data->svg_render_height;
+		gs_effect_set_vec2(data->param_svg_uv_size, &svg_uv_size);
 
-			struct vec2 offset;
-			offset.x = (float)data->offset_x;
-			offset.y = (float)data->offset_y;
-			gs_effect_set_vec2(data->param_offset, &offset);
+		struct vec2 offset;
+		offset.x = (float)data->offset_x;
+		offset.y = (float)data->offset_y;
+		gs_effect_set_vec2(data->param_offset, &offset);
 
-			gs_effect_set_float(data->param_primary_alpha, 1.0f);
-			gs_effect_set_float(data->param_secondary_alpha, 1.0f);
-			gs_effect_set_float(data->param_invert, data->invert ? 1.0f : 0.0f);
-			gs_effect_set_vec2(data->param_anchor, &data->anchor);
-			gs_effect_set_matrix4(data->param_rotation_matrix, &data->rotation_matrix);
+		gs_effect_set_float(data->param_primary_alpha, 1.0f);
+		gs_effect_set_float(data->param_secondary_alpha, 1.0f);
+		gs_effect_set_float(data->param_invert,
+				    data->invert ? 1.0f : 0.0f);
+		gs_effect_set_vec2(data->param_anchor, &data->anchor);
+		gs_effect_set_matrix4(data->param_rotation_matrix,
+				      &data->rotation_matrix);
 
-			if (base->mask_effect == MASK_EFFECT_ADJUSTMENT)
-			{
-				const float min_brightness = color_adj->adj_brightness
-					? color_adj->min_brightness
-					: 0.0f;
-				gs_effect_set_float(data->param_min_brightness, min_brightness);
-				const float max_brightness = color_adj->adj_brightness
-					? color_adj->max_brightness
-					: 0.0f;
-				gs_effect_set_float(data->param_max_brightness, max_brightness);
+		if (base->mask_effect == MASK_EFFECT_ADJUSTMENT) {
+			const float min_brightness = color_adj->adj_brightness
+							     ? color_adj->min_brightness
+							     : 0.0f;
+			gs_effect_set_float(data->param_min_brightness,
+					    min_brightness);
+			const float max_brightness = color_adj->adj_brightness
+							     ? color_adj->max_brightness
+							     : 0.0f;
+			gs_effect_set_float(data->param_max_brightness,
+					    max_brightness);
 
-				const float min_contrast = color_adj->adj_contrast
-					? color_adj->min_contrast
-					: 0.0f;
-				gs_effect_set_float(data->param_min_contrast, min_contrast);
-				const float max_contrast = color_adj->adj_contrast
-					? color_adj->max_contrast
-					: 0.0f;
-				gs_effect_set_float(data->param_max_contrast, max_contrast);
+			const float min_contrast = color_adj->adj_contrast
+							   ? color_adj->min_contrast
+							   : 0.0f;
+			gs_effect_set_float(data->param_min_contrast,
+					    min_contrast);
+			const float max_contrast = color_adj->adj_contrast
+							   ? color_adj->max_contrast
+							   : 0.0f;
+			gs_effect_set_float(data->param_max_contrast,
+					    max_contrast);
 
-				const float min_saturation = color_adj->adj_saturation
-					? color_adj->min_saturation
-					: 1.0f;
-				gs_effect_set_float(data->param_min_saturation, min_saturation);
-				const float max_saturation = color_adj->adj_saturation
-					? color_adj->max_saturation
-					: 1.0f;
-				gs_effect_set_float(data->param_max_saturation, max_saturation);
+			const float min_saturation =
+				color_adj->adj_saturation ? color_adj->min_saturation : 1.0f;
+			gs_effect_set_float(data->param_min_saturation,
+					    min_saturation);
+			const float max_saturation =
+				color_adj->adj_saturation ? color_adj->max_saturation : 1.0f;
+			gs_effect_set_float(data->param_max_saturation,
+					    max_saturation);
 
-				const float min_hue_shift = color_adj->adj_hue_shift
-					? color_adj->min_hue_shift
-					: 0.0f;
-				gs_effect_set_float(data->param_min_hue_shift, min_hue_shift);
+			const float min_hue_shift = color_adj->adj_hue_shift
+							    ? color_adj->min_hue_shift
+							    : 0.0f;
+			gs_effect_set_float(data->param_min_hue_shift,
+					    min_hue_shift);
 
-				const float max_hue_shift = color_adj->adj_hue_shift
-					? color_adj->max_hue_shift
-					: 1.0f;
-				gs_effect_set_float(data->param_max_hue_shift, max_hue_shift);
-			}
-
-			gs_blend_state_push();
-			gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-
-			obs_source_process_filter_tech_end(base->context, data->effect_svg_mask, 0, 0, technique);
-			gs_blend_state_pop();
+			const float max_hue_shift = color_adj->adj_hue_shift
+							    ? color_adj->max_hue_shift
+							    : 1.0f;
+			gs_effect_set_float(data->param_max_hue_shift,
+					    max_hue_shift);
 		}
+
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
+
+		obs_source_process_filter_tech_end(
+			base->context, data->effect_svg_mask, 0, 0,
+			technique);
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/obs-utils.c
+++ b/src/obs-utils.c
@@ -2,8 +2,17 @@
 
 gs_texrender_t *create_or_reset_texrender(gs_texrender_t *render)
 {
+	return create_or_reset_texrender_format(render, GS_RGBA);
+}
+
+gs_texrender_t *create_or_reset_texrender_format(gs_texrender_t *render,
+						 enum gs_color_format format)
+{
 	if (!render) {
-		render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		render = gs_texrender_create(format, GS_ZS_NONE);
+	} else if (gs_texrender_get_format(render) != format) {
+		gs_texrender_destroy(render);
+		render = gs_texrender_create(format, GS_ZS_NONE);
 	} else {
 		gs_texrender_reset(render);
 	}

--- a/src/obs-utils.h
+++ b/src/obs-utils.h
@@ -9,6 +9,8 @@
 #include <stdio.h>
 
 extern gs_texrender_t *create_or_reset_texrender(gs_texrender_t *render);
+extern gs_texrender_t *create_or_reset_texrender_format(
+	gs_texrender_t *render, enum gs_color_format format);
 gs_texrender_t* create_or_reset_texrender_high(gs_texrender_t* render);
 extern void set_blending_parameters();
 extern void label_indent(char *label, const char *label_text);


### PR DESCRIPTION
## Summary
- advertise the filter color space from the target source so HDR inputs stay on the HDR rendering path
- render intermediate mask passes with the source color space/format and add a linear output shader path
- premultiply mask RGB by the same mask alpha and use premultiplied blending to avoid HDR showing through behind the masked SDR result

## Testing
- Built and deployed on Windows against OBS Studio.
- Confirmed plugin files are loaded by OBS from the installed DLL and shader data.
